### PR TITLE
Fix segfault in empty cmd when split[0] is NULL

### DIFF
--- a/srcs/exec_cmd.c
+++ b/srcs/exec_cmd.c
@@ -50,6 +50,8 @@ static int		exec_cmd(char *cmd, t_list **env_list)
 
 	id_child = -1;
 	split = ft_split(cmd, ' ');
+	if (split[0] == NULL)
+		return (free_and_return(&split, 0));
 	ret = exec_builtins(split, env_list);
 	if (ret >= 0)
 		return (free_and_return(&split, ret));


### PR DESCRIPTION
### NORME OK
Quand on avait une commande vide (avec que des espaces par exemple, ou alors une suite de commandes dont une était vide comme `ls ; ; ls`), on avait un segfault. 

Normalement cette pull request devrait régler le problème. Je suis parti du principe qu'on renvoyait 0 dans `$?` dans ce cas là, comme dans bash

resolves #13 